### PR TITLE
fix duplicated key

### DIFF
--- a/zh-CN/config.cfg
+++ b/zh-CN/config.cfg
@@ -271,8 +271,6 @@ action_open_archive_tt=打开子工厂存档\n__1__
 archive_empty=[font=default-semibold]- 存档目前为空 -[/font]
 archive_filled=[font=default-semibold]- 存档目前包含 __1__ __2__ -[/font]
 action_close_archive_tt=关闭子工厂存档
-action_export_subfactory=选择要导出的子工厂，并复制生成的代码
-action_import_subfactory=粘贴一个代码，并选择你要导入的子工厂
 action_import_subfactory=使用在另一个存档中生成的字符串导入子工厂
 action_export_subfactory=将子工厂导出为可以与他人共享的字符串
 action_archive_subfactory=将选中的子工厂移动到存档，你可以使用左边的存档按钮打开它

--- a/zh-CN/config.cfg
+++ b/zh-CN/config.cfg
@@ -253,7 +253,6 @@ beacon_issue_set_amount=每台机器受影响的分享塔数量应大于 0
 
 # Picker dialog
 amount_by=按填满 __1__ 的数量
-search_button_tt=- 按下 __CONTROL__focus-search__ 来聚焦搜索框 -
 no_item_found=没有符合你搜索条件的物品
 picker_issue_select_item=选择你要添加的物品
 picker_issue_enter_amount=通过数字或传送带指定数量


### PR DESCRIPTION
There are two `search_button_tt` keys in the zh-CN locale file. Compared with the [en locale](https://github.com/ClaudeMetz/FactoryPlanner/blob/master/modfiles/locale/en/config.cfg#L237), the key in `Picker dialog` should be removed.