### PR TITLE
Retain original name for searchability

### DIFF
--- a/ja/config.cfg
+++ b/ja/config.cfg
@@ -1,5 +1,5 @@
 [mod-name]
-factoryplanner=ファクトリープランナー
+factoryplanner=ファクトリープランナー(Factory Planner)
 
 [mod-description]
 factoryplanner=このMODは、各組立ラインを構成するレシピとマシンを指定して、あらかじめ生産を計画することができます。迅速かつ直感的に使用できる強力な機能を提供し、実際に工場を建設することに集中できます。


### PR DESCRIPTION
It becomes difficult to search a mod if mod portal / in-game mod manager shows only translated name.  People usually learn a mod by the original name which appears more frequently than translated name in articles and posts on the net.

Current appearance on the in-game mod manager:

Install tab shows the original name:

<img width="1239" alt="スクリーンショット 2023-12-31 0 14 24" src="https://github.com/ClaudeMetz/FactoryPlannerLocale/assets/10973/608747c3-1eaf-49d7-b15c-3bbe8a1cd406">

Manage tab shows the translated name:

<img width="1236" alt="スクリーンショット 2023-12-31 0 13 11" src="https://github.com/ClaudeMetz/FactoryPlannerLocale/assets/10973/4e8eaf07-5973-4a04-a088-192931b37480">

Searching by the original name shows nothing:

<img width="1237" alt="スクリーンショット 2023-12-31 0 13 26" src="https://github.com/ClaudeMetz/FactoryPlannerLocale/assets/10973/fcc51b01-be7d-4a35-927d-f5b3f235fb13">



@atu4403 thoughts?