### PR TITLE
update jp locale

### DIFF
--- a/ja/config.cfg
+++ b/ja/config.cfg
@@ -4,6 +4,7 @@ factoryplanner=ファクトリープランナー(Factory Planner)
 [mod-description]
 factoryplanner=このMODは、各組立ラインを構成するレシピとマシンを指定して、あらかじめ生産を計画することができます。迅速かつ直感的に使用できる強力な機能を提供し、実際に工場を建設することに集中できます。
 
+
 [controls]
 fp_toggle_interface=開く/閉じる
 fp_toggle_compact_view=コンパクトビューの切り替え
@@ -13,6 +14,7 @@ fp_cycle_production_views=生産ビューの切り替え
 fp_up_floor=階を上がる
 fp_top_floor=最上階に移動
 fp_reverse_cycle_production_views=生産ビューの切り替えを逆にする
+fp_toggle_calculator=計算方法を切り替える
 fp_confirm_dialog=ダイアログを確認
 fp_focus_searchfield=検索フィールドにフォーカス
 
@@ -29,6 +31,7 @@ fp_reverse_cycle_production_views=生産テーブルの異なるビューを逆�
 fp_confirm_dialog=テキストフィールドがフォーカスされていなくても、任意のモーダルダイアログを確認
 fp_focus_searchfield=可能な場合、製品ピッカーの検索フィールドにカーソルをフォーカス
 
+
 [shortcut-name]
 fp_open_interface=ファクトリープランナーを開く
 
@@ -36,9 +39,12 @@ fp_open_interface=ファクトリープランナーを開く
 fp_beacon_selector=ビーコンセレクター
 
 [command-help]
-fp_reset_prototypes=ベースゲームデータからさまざまなプロトタイプを再構築。通常は必要ありません。
 fp_restart_translation=プロトタイプ名の翻訳を再開して、検索で自然言語名を使用できるようにする。
 fp_shrinkwrap_interface=画面に完全に収まるまでメインインターフェースの幅と高さを縮小。
+
+
+[fuel-category-name]
+fluid-fuel=流体燃料
 
 
 [fp]
@@ -59,25 +65,6 @@ importer_unpacking_failure=指定された文字列を適切に展開および�
 importer_issue_import_string=有効なファクトリー交換文字列をインポートしてください
 importer_issue_select_factory=少なくとも1つのファクトリーを選択してインポートしてください
 
-# チュートリアルダイアログ
-tutorial=チュートリアル
-interactive_tutorial_title=インタラクティブチュートリアル
-interactive_tutorial_text=ファクトリープランナーに慣れる最良の方法は、ただ直接飛び込んで自分でそれを探索することです。そのため、このmodのいくつかの重要な機能を示すサンプルファクトリーを含めました。下のボタンをクリックすることで追加できます。また、[font=default-semibold]チュートリアルモード[/font]をアクティブにすることもできます。これにより、インタフェース全体の重要なボタンで可能なキーボードの組み合わせをすべて表示します。
-create_example=例を作成
-create_example_error=現在のmodのセットと互換性がないため、サンプルファクトリーを作成できません。
-tutorial_mode=チュートリアルモード
-interface_tutorial_title=インタラクション
-interface_tutorial_text=インタフェースは、同様のアクションが同じショートカットを共有するように設定されているため、特定の結果を達成する方法を直感的に理解しやすくなっています。これらの基本的なインタラクションを内部化し、それらをどこでも使用するだけです：
-interface_controls=• [font=default-semibold][color=#84CDEC]左クリック[/color][/font]: 選択/使用\n• [font=default-semibold][color=#84CDEC]右クリック[/color][/font]: 編集\n• [font=default-semibold][color=#84CDEC]Control + 右クリック[/color][/font]: 削除\n• [font=default-semibold][color=#84CDEC]Shift + 右クリック[/color][/font]: コピー\n• [font=default-semibold][color=#84CDEC]Shift + 左クリック[/color][/font]: 貼り付け\n• [font=default-semibold][color=#84CDEC]Alt + 左クリック[/color][/font]: カーソルに入れる
-interface_controls_recipebook=\n• [font=default-semibold][color=#84CDEC]Alt + 右クリック[/color][/font]: Recipe Bookで開く
-
-# アイテムオプションダイアログ
-options_item_title=__1__の量を設定
-options_item_text='__1__'の特定の量を設定
-options_item_amount=量
-options_item_amount_tt=この__1__の正確な量を指定して、このレシピで__2__してほしい。これにより、この行のパーセンテージがそれに応じて調整されます。
-options_factory_ingredient_amount_tt=この材料の正確な量を指定して、この工場が消費する量を指定します。これにより、その製品の量がそれに応じて調整されます。
-
 # ユーティリティダイアログ
 utilities=ユーティリティ
 utility_title_components=コンポーネント
@@ -85,16 +72,24 @@ utility_title_components_tt=現在の工場/階を構築するために必要な
 utility_title_blueprints=ブループリント
 utility_title_blueprints_tt=現在の工場と一緒に関連するブループリントを保存することができます。ブループリントを持って'+'ボタンをクリックして追加します。
 utility_title_notes=ノート
+utility_title_productivity_boni=レシピの生産性
+utility_title_productivity_boni_tt=研究により追加される生産性ボーナスを上書きできるようにします。
 components_needed_tt=__1__\n[font=default-bold]__2__[/font] 在庫 / [font=default-bold]__3__[/font] 必要\n[font=default-semibold][color=#84CDEC]左クリック[/color][/font] でこのアイテムを手作り
 no_components_needed=__1__は不要
+import_from=インポート
+import_from_tt=カスタムされたレシピの生産性ボーナス設定を別のファクトリーからインポートします。
+current=現在の
+custom=カスタム
+mining_recipes=採掘レシピ
+
 utility_combinator_tt=インベントリにないすべてのアイテムを、定数回路を含むブループリント文字列に変換します。定数回路を要求チェストに接続して、配信させることができます。
+utility_request_tt=不足しているアイテムをすべてリクエストします。\nこれは、キャラクターに新しい物流グループを作成することによって行われます。このグループはいつでも削除できます。
 utility_no_items_necessary=あなたのインベントリはすでにこの__1__を構築するために必要なすべてのアイテムを含んでいます。
-request_items=要求
-request_items_tt=この__1__を構築するためにインベントリに欠けているすべてのアイテムを要求します。\n[font=default-semibold][color=#84CDEC]注:[/color][/font] これは、個人のroboportボットを含む建設ボット（ロジスティクスボットではない）を使用します。アイテムを要求する前に個人のroboportを無効にすることをお勧めします。
-cancel_request=キャンセル
-request_logistics_not_researched=この機能を有効にするには、ロボティクス技術を研究する必要があります。
-request_no_character=アイテムを要求するためには、キャラクターが関連付けられている必要があります。
-utility_no_character=関連するキャラクターなしで手作りできません
+utility_logistics_not_researched=この機能を有効にするには、ロボティクス技術を研究する必要があります。
+utility_logistics_no_character=アイテムを要求するためには、キャラクターが関連付けられている必要があります。
+utility_logistics_request_set=物流リクエストグループが正常に作成されました！
+
+utility_crafting_no_character=関連するキャラクターなしで手作りできません
 utility_no_crafting=このプレイヤーに対してクラフトを無効にする権限があります
 utility_no_recipes=このアイテムを作成するレシピはありません
 utility_no_demand=このアイテムの需要はすでに満たされています
@@ -110,7 +105,6 @@ utility_blueprint_stored=ブループリントが保存されました！
 preferences=設定
 preferences_support=[font=default-semibold][color=#84CDEC]https://ko-fi.com/therenas[/color][/font]で私をサポートしてください！
 rows=行
-per_timescale=__1__ごと
 
 preference_general_title=一般の設定
 preference_general_title_tt=定期的に変更したいいくつかの一般的な設定
@@ -128,8 +122,6 @@ preference_general_fold_out_subfloors=サブフロアを展開
 preference_general_fold_out_subfloors_tt=階層に入る必要はなく、工場のトップレベルですべてのサブフロアを表示します。
 preference_general_ingredient_satisfaction=成分の満足度
 preference_general_ingredient_satisfaction_tt=レシピの成分要求がそれより下のレシピによって満たされているかどうかを表示します。
-preference_general_round_button_numbers=丸められたボタンの数字
-preference_general_round_button_numbers_tt=マシンボタンとベルト/レーンボタンの数字を丸めます。
 preference_general_ignore_barreling_recipes=バレリング/スタッキングレシピを無視
 preference_general_ignore_barreling_recipes_tt=レシピを探すときに（un）barrelingおよび（un）stackingを無視することができます（互換性のあるmodのみ）。
 preference_general_ignore_recycling_recipes=リサイクルレシピを無視
@@ -139,8 +131,6 @@ preference_dropdown_products_per_row=インタフェースの幅
 preference_dropdown_products_per_row_tt=1行に表示されるトップレベル製品の数を選択することで、メインインタフェースの幅を設定します。
 preference_dropdown_factory_list_rows=インタフェースの高さ
 preference_dropdown_factory_list_rows_tt=工場名が合計で表示される数を選択することで、メインインタフェースの高さを設定します。
-preference_dropdown_default_timescale=デフォルトのタイムスケール
-preference_dropdown_default_timescale_tt=新しい工場が作成されるときに使用されるタイムスケールを選択します。
 
 preference_production_title=生産テーブルの列
 preference_production_title_tt=これにより、生産テーブルにいくつかの追加列を有効にできます。
@@ -148,34 +138,18 @@ preference_production_done_column=レシピを完了としてマーク
 preference_production_done_column_tt=レシピを完了としてマークするボタンを含む列を追加し、これはあなたにとって純粋に視覚的な情報として機能し、レシピ自体には影響を与えません。
 preference_production_percentage_column=パーセンテージ
 preference_production_percentage_column_tt=レシピの製品の需要のパーセンテージを指定できるテキストフィールドを含む列を追加します。
-preference_production_pollution_column=汚染
-preference_production_pollution_column_tt=このレシピによって生じる汚染を表示する列を追加します。
 preference_production_line_comment_column=レシピのコメント
 preference_production_line_comment_column_tt=個々のレシピにノートを取ることができるテキストフィールドを含む列を追加します。
 
-preference_mb_defaults_title=モジュールのデフォルト
-preference_mb_defaults_title_tt=互換性がある場合、すべての新しいレシピが設定されるデフォルトのモジュールを設定します。
-preference_mb_default_machine=プライマリ
-preference_mb_default_machine_tt=互換性がある場合、新しいレシピが設定される最初のモジュール
-preference_mb_default_machine_secondary=セカンダリ
-preference_mb_default_machine_secondary_tt=最初のモジュールが新しいレシピと互換性がない場合、このモジュールが代わりに使用されます（互換性がある場合）。
-preference_mb_default_beacon=モジュール
-preference_mb_default_beacon_tt=互換性がある場合、すべての新しいレシピのビーコンに設定されるデフォルトのモジュール
-preference_mb_default_beacon_amount=量
-preference_mb_default_beacon_amount_tt=新しいレシピの個々のマシンがどれだけのビーコンに影響を受けるかを指定します。
-
 preference_default_belts_title=優先ベルト
 preference_default_belts_title_tt=ベルト/レーンの需要を計算するとき、またはベルト/レーンの量で製品を指定するときに使用されるベルトのタイプを設定します。
-preference_default_beacons_title=優先ビーコン
-preference_default_beacons_title_tt=レシピに追加するときにデフォルトで選択されるビーコンを設定します。
-preference_default_fuels_title=優先燃料
-preference_default_fuels_title_tt=燃料の必要なマシンを追加するときにデフォルトで選択される燃料を設定します。
-preference_default_machines_title=優先マシン
-preference_default_machines_title_tt=新しいレシピを追加するときに各カテゴリーでデフォルトで選択されるマシンを設定します。\n[font=default-semibold][color=#84CDEC]Shift + 左クリック[/color][/font] で、他のすべての類似したカテゴリーにそれを設定します。
+preference_belts_or_lanes_tt=アイテムのスループットを個々のレーンとして考えるか、フルベルトとして考えるかを示します。
 preference_default_wagons_title=優先ワゴン
 preference_default_wagons_title_tt=ワゴン需要を計算するときに使用されるワゴンのタイプを設定します。
 
-preference_belts_or_lanes_tt=アイテムのスループットを個々のレーンとして考えるか、フルベルトとして考えるかを示します。
+preference_views_title=アイテム生産効率の表示
+preference_views_title_tt=アイテム生産効率に使用する単位と、その順序を設定してください
+preference_pick_views=最大4つの異なる単位を選択します
 
 # レシピダイアログ
 recipe_instruction='__2__'を__1__するレシピを選択してください
@@ -184,14 +158,28 @@ unresearched_recipes=未研究のレシピ
 hidden_recipes=非表示のレシピ
 no_recipe_found=フィルタ条件に一致するレシピはありません
 
-# リモートインタフェース
-interface_name_fnei=FNEI
-interface_name_wiiruf=WIIRUF
-interface_name_recipebook=Recipe Book
-
 # ジェネレーター
-fluid_at_temperature=__2__ __3__での__1__
-ore_deposit=(鉱床)
+deposit=(鉱床)
+lake=(溶岩)
+launch=(打ち上げ)
+mining_recipe=(掘削)
+pumping_recipe=(ポンプ)
+planting_recipe=(農業)
+spoiling_recipe=(非表示)
+agriculture_square=農業タワー
+agriculture_unit=squares
+time=時間
+time_unit=秒
+catalyst=培養
+recipe_none=\n  なし
+
+
+
+
+
+
+
+
 
 # モーダルダイアログ
 submit=送信
@@ -201,6 +189,7 @@ confirm_dialog_tt=- __CONTROL__fp_confirm_dialog__を押して確認 -
 cancel_dialog_tt=- __CONTROL__toggle-menu__を押してキャンセル -
 search_button_tt=- __CONTROL__focus-search__を押して検索フィールドにフォーカス -
 reset_button_tt=クリックしてすべての設定をデフォルトにリセット
+reset_confirm_tt=よろしいですか?
 close_button_tt=- __CONTROL__toggle-menu__を押して閉じる -
 searchfield_tt=自然言語の名前を使用して結果をフィルタリング
 searchfield_not_ready_tt=自然言語検索はまだ準備ができていません、お待ちください。\n[font=default-semibold]' /fp-restart-translation '[/font]コンソールコマンドを使用して再起動します。
@@ -213,14 +202,12 @@ picker_issue_select_item=追加するアイテムを選択してください
 picker_issue_enter_amount=数量を数字またはベルトで指定してください
 
 # 工場ダイアログ
-factory_dialog_description=工場の名前を選んでください
-factory_dialog_name=名前
+factory_dialog_description=工場の名前を入力して
 factory_dialog_name_tt=工場名はリッチテキストを許可し、以下のボタンを使用して追加できます
 factory_dialog_rich_text=リッチテキスト
 factory_dialog_rich_text_tt=これらのセレクターは、工場名にリッチテキストを追加するために使用できます。もちろん、自分でリッチテキストを入力するか貼り付けることもできます。
 factory_dialog_signals=シグナル
 factory_dialog_recipes=レシピ
-factory_dialog_name_empty=工場の名前は空にできません
 
 # マシンダイアログ
 machine_dialog_description='__1__'のマシンを設定する
@@ -229,6 +216,7 @@ machine_limit=制限
 machine_limit_tt=この行が使用するマシンの数を制限します。必要なマシンが少ない場合、実際の量は低くなる可能性があります。
 machine_force_limit=正確な制限
 machine_force_limit_tt=上記で指定された正確な数量のマシンを強制します、たとえこれが過剰生産につながるとしても。マシン制限と組み合わせてのみ意味があります。
+machine_effects_tt=マシンには[font=default-semibold][color=#7CFF01]緑[/color][/font]でマークされた固有の効果がある場合があります.\n研究により、[font=default-semibold][color=#01FFF4]青[/color][/font]でマークされた効果を有効にすることもできます。
 
 # ビーコンダイアログ
 beacon_dialog_description_add='__1__'にビーコンを追加
@@ -240,11 +228,21 @@ beacon_selector_tt=選択ツールを使用して、すでに建設された工�
 beacon_issue_set_amount=0より大きいビーコンの数量を入力してください
 beacon_issue_no_modules=少なくとも1つのモジュールを選択してください
 
+# モジュールの構成
+configurator_duplicate_module=同じ品質の同一モジュールを2つ設定することはできません
+
+# 計算機ダイアログ
+calculator=計算機
+toggle_history_tt=履歴の切り替え
+
 # タイトルバー
 switch_to_compact_view=コンパクトビューに切り替え\n- __CONTROL__fp_toggle_compact_view__を押して切り替え -
 pause=一時停止
 pause_on_interface=メインインターフェースが開いている間、ゲームを自動的に一時停止するように切り替え（シングルプレイヤーのみ）\n- __CONTROL__fp_toggle_pause__を押して一時停止を切り替え -
 close_interface=このインターフェースを閉じる\n- __CONTROL__fp_toggle_interface__を押して閉じる -
+
+# 地区情報
+view_districts=クリックして地区を表示または変更します
 
 # 工場リスト
 action_open_archive_tt=工場アーカイブを開く\n__1__
@@ -256,13 +254,24 @@ action_export_factory=他の人と共有できる文字列に工場をエクス�
 action_archive_factory=選択した工場をアーカイブに移動
 action_unarchive_factory=選択した工場をアーカイブから戻す
 action_duplicate_factory=選択した工場を複製し、完璧なコピーを作成
-action_add_factory_by_name=新しい工場を作成\n[font=default-semibold][color=#84CDEC]Shift + Left-Click[/color][/font] ですぐに製品を選択
-action_add_factory_by_product=新しい工場のアイテムを選択\n[font=default-semibold][color=#84CDEC]Shift + Left-Click[/color][/font] で最初に名前を付ける
+action_add_factory_by_name=新しい工場を作成\n[font=default-semibold][color=#84CDEC]Shift + 左クリック[/color][/font] ですぐに製品を選択
+action_add_factory_by_product=新しい工場のアイテムを選択\n[font=default-semibold][color=#84CDEC]Shift + 左クリック[/color][/font] で最初に名前を付ける
 action_edit_factory=選択した工場の名前を編集
 action_trash_factory=選択した工場をゴミ箱に移動\n__1__分間アーカイブに保持されます
 action_delete_factory=選択した工場を完全に削除
 factory_trashed=\n[font=default-bold]ゴミ箱に入れられました[/font] - 自動削除は __1__ __plural_for_parameter__1__{1=分後|rest=分後}__
 factory_invalid=\n[font=default-bold]無効[/font] - 修理が必要です
+
+# 地区ボックス
+edit_name=名前を編集
+save_name=名前を保存
+u_select=選択
+u_selected=選択済み
+add_district=地区を追加
+location_tt=場所により、クラフト可能なレシピと汚染の種類を設定されます。
+item_amount_product=\余剰 __1__
+item_amount_ingredient=\n不足 __1__
+item_amount_total=\n合計 __1__
 
 # 工場情報
 factory_info=工場情報
@@ -345,34 +354,37 @@ clipboard_already_exists=貼り付けた__1__はすでに存在します
 clipboard_no_empty_slots=空のモジュールスロットがありません
 clipboard_recipe_irrelevant=このフロアに関係のない貼り付け行
 
-# チュートリアルモード
-tut_action_line=\n[font=default-semibold][color=#84CDEC]__1__[/color][/font] で __2__を行います
+# 編集アクション
+action_click=[font=default-semibold][color=#84CDEC]__1__[/color][/font]
+action_line=\n[font=default-semibold][color=#84CDEC]__1__:[/color][/font] __2__
+action_all=\n[font=default-semibold][color=#84CDEC]右クリック[/color]で全てのアクションを表示します[/font]
 
-tut_left=左クリック
-tut_right=右クリック
-tut_shift=shift
-tut_control=ctrl
-tut_alt=alt
 
-tut_select=選択
-tut_edit=編集
-tut_delete=削除
-tut_copy=コピー
-tut_paste=貼り付け
-tut_add_recipe=レシピを追加
-tut_move_left=左に移動
-tut_move_right=右に移動
-tut_open_subfloor=サブフロアを開く
-tut_toggle=切り替え
-tut_set_limit=制限を設定
-tut_reset_to_default=デフォルトにリセット
-tut_put_into_cursor=カーソルに入れる
-tut_add_recipe_to_end=レシピを追加
-tut_add_recipe_below=以下にレシピを追加
-tut_specify_amount=数量を指定
-tut_prioritize=優先する
-tut_pick_up=拾う
-tut_recipebook=Recipe Bookで開く
+action_left=左クリック
+action_right=右クリック
+action_shift=shift
+action_control=ctrl
+action_alt=alt
+
+action_select=選択
+action_edit=編集
+action_delete=削除
+action_copy=コピー
+action_paste=貼り付け
+action_add_recipe=レシピを追加
+action_move_left=左に移動
+action_move_right=右に移動
+action_open_subfloor=サブフロアを開く
+action_toggle=切り替え
+action_set_limit=制限を設定
+action_reset_to_default=デフォルトにリセット
+action_put_into_cursor=カーソルに入れる
+action_add_recipe_to_end=レシピを追加
+action_add_recipe_below=以下にレシピを追加
+action_specify_amount=数量を指定
+action_prioritize=優先する
+action_pick_up=拾う
+action_factoriopedia=ファクトリオペディアで開く
 
 # 効果のツールチップ
 effect_line=\n__1__: [font=default-semibold][color=#FFE6C0]__2__%[/color][/font] __3__
@@ -383,6 +395,17 @@ pollution=汚染
 base_prod=基本生産性
 mining_prod=鉱山生産性
 effect_maxed=(最大化)
+quality=品質
+
+# デフォルトフレーム
+defaults=デフォルト
+current_default=[font=default-bold]現在のデフォルト[/font]
+save_as_default_machine=[font=default-semibold]デフォルトとして設定[/font]\n現在のマシンとそのモジュールをそのカテゴリのデフォルトとして保存します。
+save_as_default_fuel=[font=default-semibold]デフォルトとして設定[/font]\n現在の燃料をそのカテゴリのデフォルトとして保存します。
+save_as_default_beacon=[font=default-semibold]デフォルトとして設定[/font]\n現在のビーコンとそのモジュールをデフォルトとして保存します。
+save_for_all_machine=[font=default-semibold]すべてのカテゴリに設定[/font]\n現在のマシンとそのモジュールを、それが属するすべてのカテゴリのデフォルトとして保存します。
+save_for_all_fuel=[font=default-semibold]すべてのカテゴリに設定[/font]\n現在の燃料を、それが属するすべてのカテゴリのデフォルトとして保存します。
+save_beacon_amount=[font=default-semibold]数量を設定[/font]\n現在のビーコンの数量をデフォルトとして保存します。
 
 # メッセージ
 error_no_relevant_recipe=このアイテムを生産する既存のレシピはありません
@@ -396,8 +419,6 @@ error_recipe_wrong_floor=__1__ レシピは工場のトップレベルにのみ�
 warning_recipe_disabled=このレシピはまだ研究されていないため、現在は生産できません
 warning_module_not_compatible=お気に入りの__1__はこのマシンと互換性がありません
 warning_no_prioritizing_single_product=単一の関連製品しか持たないレシピは優先できません
-hint_tutorial=Factory Plannerに慣れていない場合は、右上のチュートリアルをご覧ください！
-hint_byproducts_removed=マトリックスソルバーを無効にすると、すべての副産物レシピが削除されます
 
 # 単位
 prefix_kilo=k
@@ -440,6 +461,8 @@ increased=増加
 decreased=減少
 capped=制限
 
+name=名前
+
 on=オン
 off=オフ
 left=左
@@ -474,13 +497,15 @@ combinator=コンビネータ
 put_into_cursor_failed=__1__はカーソルに入れることはできません
 blueprint_no_combinator_prototype=定数コンビネータのプロトタイプが見つかりません
 
-move_row_tt=この__1__を__2__に移動\n[font=default-semibold][color=#84CDEC]Control + Left-Click[/color][/font]で5スポット移動\n[font=default-semibold][color=#84CDEC]Shift + Left-Click[/color][/font]で__3__に移動
+move_row_tt=この__1__を__2__に移動\n[font=default-semibold][color=#84CDEC]Control + 左クリック[/color][/font]で5スポット移動\n[font=default-semibold][color=#84CDEC]Shift + 左クリック[/color][/font]で__3__に移動
 attribute_line=\n[font=default-semibold][color=#FFE6C0]__1__:[/color][/font] __2__
-shift_to_paste=[font=default-semibold][color=#84CDEC]Shift + Left-Click[/color][/font]で貼り付け
+shift_to_paste=[font=default-semibold][color=#84CDEC]Shift + 左クリック[/color][/font]で貼り付け
 
 mod_reset=[color=#FF3333]Factory Plannerがリセットされました！[/color] バージョン1.1.60より前のバージョンはこのバージョンに移行できないため、ユーザーデータが削除されました。この保存を最新の状態にするには、Factory Plannerバージョン1.1.60で読み込んで保存し、その後このバージョンで読み込んでください。[color=#CCCC00]古いデータを保持したい場合は、このマップを保存しないでください！[/color]
 
-# Locale prefixes: s = singular; p = plural; l = lowercase; u = uppercase
+# 複数形(日本語には複数形がありませんが、個数が指定される時「__1__～つの(何か)」が使用されるため要検討)
+pl_district=__plural_for_parameter__1__{1=district|rest=districts}__
+pu_district=__plural_for_parameter__1__{1=District|rest=Districts}__
 pl_factory=__plural_for_parameter__1__{1=factory|rest=factories}__
 pu_factory=__plural_for_parameter__1__{1=Factory|rest=Factories}__
 pl_floor=__plural_for_parameter__1__{1=floor|rest=floors}__
@@ -489,8 +514,6 @@ pl_line=__plural_for_parameter__1__{1=line|rest=lines}__
 pu_line=__plural_for_parameter__1__{1=Line|rest=Lines}__
 pl_item=__plural_for_parameter__1__{1=item|rest=items}__
 pu_item=__plural_for_parameter__1__{1=Item|rest=Items}__
-pl_simpleitem=__plural_for_parameter__1__{1=item|rest=items}__
-pu_simpleitem=__plural_for_parameter__1__{1=Item|rest=Items}__
 pl_fluid=__plural_for_parameter__1__{1=fluid|rest=fluids}__
 pu_fluid=__plural_for_parameter__1__{1=Fluid|rest=Fluids}__
 pl_product=__plural_for_parameter__1__{1=product|rest=products}__
@@ -516,6 +539,15 @@ pu_lane=__plural_for_parameter__1__{1=Lane|rest=Lanes}__
 pl_wagon=__plural_for_parameter__1__{1=wagon|rest=wagons}__
 pu_wagon=__plural_for_parameter__1__{1=Wagon|rest=Wagons}__
 pl_stack=__plural_for_parameter__1__{1=stack|rest=stacks}__
+pu_stack=__plural_for_parameter__1__{1=Stack|rest=Stacks}__
+pl_location=__plural_for_parameter__1__{1=location|rest=locations}__
+pu_location=__plural_for_parameter__1__{1=Location|rest=Locations}__
+pl_rocket=__plural_for_parameter__1__{1=rocket|rest=rockets}__
+pu_rocket=__plural_for_parameter__1__{1=Rocket|rest=Rockets}__
 
-l_fluid=fluid
-u_power=Power
+
+l_fluid=流体
+u_power=電力
+u_factory=ファクトリー
+u_archive=アーカイブ
+u_production=生産


### PR DESCRIPTION
Translated many and remove unused translation keys.


Plurals should be translated like them in japanese:

Factory:工場
1 factory:1つの工場
2 factorys:2つの工場

But I can't find how to do in Localisation tutorial
what it should be?