### PR TITLE
Fix unable to close compact view in French

### DIFF
--- a/fr/config.cfg
+++ b/fr/config.cfg
@@ -2,7 +2,7 @@
 
 
 [mod-name]
-factoryplanner=Factory Planner (Planificateur d’usine) (by bev &  Fr_Dae)
+factoryplanner=Planificateur d’usine (Factory Planner)
 
 
 [mod-description]


### PR DESCRIPTION
In compact view, the window title was too long and covered the close button so that it was impossible to close the window.
<img width="1109" height="268" alt="Capture d’écran 2025-07-18 à 19 54 54" src="https://github.com/user-attachments/assets/7e05c8e7-7efa-4545-bb03-6e85bbb95b7a" />

Also, I just found it distasteful that people other than mod authors added their names there, and even mod authors did not do that.

Second change, now the French word is first, with original word in parenthesis.